### PR TITLE
Fix install bug

### DIFF
--- a/QuadTreeAttention/QuadtreeAttention/src/value_aggregation.cpp
+++ b/QuadTreeAttention/QuadtreeAttention/src/value_aggregation.cpp
@@ -1,7 +1,7 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "value_aggregation.h"
-extern THCState *state;
+//extern THCState *state;
 #define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)


### PR DESCRIPTION
error: ‘THCState’ does not name a type; did you mean ‘THPDtype’? After comment out the unused `state`, success.